### PR TITLE
fix: avoid assumptions about record separators

### DIFF
--- a/examples/word-count.awk
+++ b/examples/word-count.awk
@@ -1,15 +1,17 @@
 # AWK word cound mimicking wc tool functionality
+#   requires gawk
 
 # actions before reading text stream
 BEGIN {
   fcnt = bcnt = 0;
+  RS="(\n|\n\r|\r\n)"; # gawk extension
 }
 
 # at each line actions
 {
   # accumulate the counters
   fcnt += NF;
-  bcnt += length($0) + 1;
+  bcnt += length($0) + length(RT);
 }
 
 # actions when text stream read

--- a/examples/word-count.awk
+++ b/examples/word-count.awk
@@ -4,7 +4,8 @@
 # actions before reading text stream
 BEGIN {
   fcnt = bcnt = 0;
-  RS="(\n|\n\r|\r\n)"; # gawk extension
+  # Linux, OSX: LF; Windows: CR LF; old Mac CR
+  RS="(\n|\r\n|\r)"; # gawk extension
 }
 
 # at each line actions

--- a/examples/word-count.md
+++ b/examples/word-count.md
@@ -16,7 +16,7 @@ $ ps auxww > /tmp/ps.log
 $ wc  /tmp/ps.log
   389  4737 37752 /tmp/ps.log
 
-$ awk -f word-count.awk  /tmp/ps.log
+$ gawk -f word-count.awk  /tmp/ps.log
   389  4737  37752 /tmp/ps.log
 ```
 


### PR DESCRIPTION
This PR introduces more precise detection of record separator in order to handle gracefully files with different line ending or without linebreak (at the end of file).

Technically awk program now defines how record separator should look like (setting `RS` to regexp) and count aractual recod separator length (`RT`).

```
[freznicek@quad examples]$ wc word-count.md.*
  24   88  599 word-count.md.dos   # win/dos ending
  23   88  574 word-count.md.m1    # linux ending without line separator at the end of file
  24   88  575 word-count.md.0     # linux ending with line separator at the end of file
[freznicek@quad examples]$ gawk -f word-count.awk word-count.md.0
24 88 575 word-count.md.0
[freznicek@quad examples]$ gawk -f word-count.awk word-count.md.m1 
24 88 574 word-count.md.m1
[freznicek@quad examples]$ gawk -f word-count.awk word-count.md.dos 
24 88 599 word-count.md.dos

```
fixes #1 